### PR TITLE
Moved attribute to match documentation

### DIFF
--- a/View.elm
+++ b/View.elm
@@ -44,12 +44,12 @@ view model =
                     []
                     [ Html.text "Translate Text"
                     , Html.input
-                        [ Html.Attributes.type' "checkbox"
-                        , Html.Events.onClick Update.ToggleDirection
-                        ]
+                        [ Html.Attributes.type' "checkbox" ]
                         []
                     , Html.span
-                        [ Html.Attributes.class "lever" ]
+                        [ Html.Attributes.class "lever"
+                        , Html.Events.onClick Update.ToggleDirection
+                        ]
                         []
                     , Html.text "Translate Emoji"
                     ]


### PR DESCRIPTION
In the 

> Our First Full Feature

 section of the Elmoji Translator instructions, it says:

> Add the following attribute to the lever's HTML in View.view:
> `Html.Events.onClick Update.ToggleDirection`

but [the final code example](https://github.com/elmbridge/elmoji-translator/blob/release-4-part-3/View.elm) has the attribute in the **checkbox’s** HTML.
